### PR TITLE
Fix signature help when no symbol provided by DCD

### DIFF
--- a/source/served/extension.d
+++ b/source/served/extension.d
@@ -889,10 +889,13 @@ SignatureHelp provideSignatureHelp(TextDocumentPositionParams params)
 			auto symbols = "symbols" in result;
 			if (symbols && symbols.type == JSON_TYPE.ARRAY && i < symbols.array.length)
 			{
-				auto symbol = symbols.array[i];
-				auto doc = "documentation" in symbol;
-				if (doc && doc.str.length)
-					sig.documentation = MarkupContent(doc.str.ddocToMarked);
+				immutable auto symbol = symbols.array[i];
+				if (symbol.type == JSON_TYPE.OBJECT)
+				{
+					auto doc = "documentation" in symbol;
+					if (doc && doc.str.length)
+						sig.documentation = MarkupContent(doc.str.ddocToMarked);
+				}
 			}
 			auto funcParams = calltip.str.extractFunctionParameters;
 


### PR DESCRIPTION
Tracing the result from dcd shows a bunch of nulls in the symbols array.
Every index will be JSON_TYPE.NULL. Thus the associative array "in" will fail miserably.

