### PR TITLE
Improve windows build script

### DIFF
--- a/release.bat
+++ b/release.bat
@@ -1,19 +1,32 @@
 rem Building & compressing serve-d for release inside a virtual machine with Windows 8 or above
-rem This will delete the folder C:\build
 
-del /S /Q C:\build
-xcopy /e . C:\build
-pushd C:\build
+cd %~dp0
+
+@if not exist version.txt (
+	echo.
+    echo !-- Error: version.txt is missing :/
+    echo.
+    pause
+    goto :eof
+)
+
+rem This will sync this repo with the folder %windir%\..\buildsd
+robocopy . %windir%\..\buildsd /MIR /XA:SH /XD .* /XF .* /XF *.zip
+pushd %windir%\..\buildsd
+
 set /p Version=<version.txt
 dub build --compiler=ldc2 --arch=x86
-echo Y | del windows
+
+if exist windows del /S /Q windows
 mkdir windows
-echo F | xcopy /f serve-d.exe windows\serve-d.exe
-echo F | xcopy /f libcurl.dll windows\libcurl.dll
-echo F | xcopy /f libeay32.dll windows\libeay32.dll
-echo F | xcopy /f ssleay32.dll windows\ssleay32.dll
-del C:\build\windows.zip
+copy serve-d.exe windows\serve-d.exe
+copy libcurl.dll windows\libcurl.dll
+copy libeay32.dll windows\libeay32.dll
+copy ssleay32.dll windows\ssleay32.dll
+
+if exist windows.zip del windows.zip
 powershell -nologo -noprofile -command "& { Add-Type -A 'System.IO.Compression.FileSystem'; [IO.Compression.ZipFile]::CreateFromDirectory('windows', 'windows.zip'); }"
 popd
-echo F | xcopy C:\build\windows.zip serve-d-%Version%-windows.zip
+
+move %windir%\..\buildsd\windows.zip "serve-d-%Version%-windows.zip"
 pause

--- a/release.bat
+++ b/release.bat
@@ -10,9 +10,9 @@ cd %~dp0
     goto :eof
 )
 
-rem This will sync this repo with the folder %windir%\..\buildsd
-robocopy . %windir%\..\buildsd /MIR /XA:SH /XD .* /XF .* /XF *.zip
-pushd %windir%\..\buildsd
+rem This will sync this repo with the folder %SystemDrive%\buildsd
+robocopy . %SystemDrive%\buildsd /MIR /XA:SH /XD .* /XF .* /XF *.zip
+pushd %SystemDrive%\buildsd
 
 set /p Version=<version.txt
 dub build --compiler=ldc2 --arch=x86
@@ -28,5 +28,5 @@ if exist windows.zip del windows.zip
 powershell -nologo -noprofile -command "& { Add-Type -A 'System.IO.Compression.FileSystem'; [IO.Compression.ZipFile]::CreateFromDirectory('windows', 'windows.zip'); }"
 popd
 
-move %windir%\..\buildsd\windows.zip "serve-d-%Version%-windows.zip"
+move %SystemDrive%\buildsd\windows.zip "serve-d-%Version%-windows.zip"
 pause

--- a/release.bat
+++ b/release.bat
@@ -7,6 +7,7 @@ pushd %~dp0
     echo !-- Error: version.txt is missing :/
     echo.
     pause
+    popd
     goto :eof
 )
 

--- a/release.bat
+++ b/release.bat
@@ -1,6 +1,6 @@
 rem Building & compressing serve-d for release inside a virtual machine with Windows 8 or above
 
-cd %~dp0
+pushd %~dp0
 
 @if not exist version.txt (
 	echo.
@@ -30,4 +30,5 @@ powershell -nologo -noprofile -command "& { Add-Type -A 'System.IO.Compression.F
 popd
 
 move %SystemDrive%\buildsd\windows.zip "serve-d_%Version%-windows.zip"
+popd
 pause

--- a/release.bat
+++ b/release.bat
@@ -15,6 +15,7 @@ robocopy . %SystemDrive%\buildsd /MIR /XA:SH /XD .* /XF .* /XF *.zip
 pushd %SystemDrive%\buildsd
 
 set /p Version=<version.txt
+dub upgrade
 dub build --compiler=ldc2 --arch=x86
 
 if exist windows del /S /Q windows
@@ -28,5 +29,5 @@ if exist windows.zip del windows.zip
 powershell -nologo -noprofile -command "& { Add-Type -A 'System.IO.Compression.FileSystem'; [IO.Compression.ZipFile]::CreateFromDirectory('windows', 'windows.zip'); }"
 popd
 
-move %SystemDrive%\buildsd\windows.zip "serve-d-%Version%-windows.zip"
+move %SystemDrive%\buildsd\windows.zip "serve-d_%Version%-windows.zip"
 pause


### PR DESCRIPTION
- Get rid of locale-dependent commands
- Change build dir and make it relative to %windir%
- Sync build dir instead of delete+copy
- Move output zip instead of copying it

Works fine here :smile: 
...but test & review it, please.