### PR TITLE
Fixed dcd download error

### DIFF
--- a/source/served/commands/dcd_update.d
+++ b/source/served/commands/dcd_update.d
@@ -101,7 +101,8 @@ void updateDCD()
 		else
 			static assert(false);
 
-		import std.net.curl : download;
+		import std.stdio : File;
+		import std.net.curl : HTTP;
 		import std.process : pipeProcess, Redirect, Config, wait;
 		import std.zip : ZipArchive;
 
@@ -109,7 +110,12 @@ void updateDCD()
 		{
 			rpc.notifyMethod("coded/logInstall", "Downloading from " ~ url ~ " to " ~ outputFolder);
 			string destDir = buildPath(outputFolder, url.baseName);
-			download(url, destDir);
+			auto f = File(destDir, "wb");
+			auto conn = HTTP(url);
+			conn.verifyPeer = false;
+			conn.onReceive = (ubyte[] data) { f.rawWrite(data); return data.length; };
+			conn.perform();
+
 			rpc.notifyMethod("coded/logInstall", "Extracting download...");
 			if (url.endsWith(".tar.gz"))
 			{


### PR DESCRIPTION
Fixes the download error reported in https://github.com/Pure-D/serve-d/issues/53#issuecomment-454334628


```
Installing DCD
Downloading from https://github.com/dlang-community/DCD/releases/download/v0.10.2/dcd-v0.10.2-windows-x86.zip to C:\Users\João Paulo\AppData\Roaming\code-d\bin
Failed installing: std.net.curl.CurlException@std\net\curl.d(4365): Peer certificate cannot be authenticated with given CA certificates on handle 1A72960
----------------
0x00D6DB87 in std.exception.bailOut!(std.net.curl.CurlException).bailOut at C:\D\dmd2\windows\bin\..\..\src\phobos\std\exception.d(515)
0x00D66C9A in std.exception.enforce!(std.net.curl.CurlException).enforce!bool.enforce at C:\D\dmd2\windows\bin\..\..\src\phobos\std\exception.d(437)
0x00DB07B6 in void std.net.curl.Curl._check(int)
0x0096143F in std.net.curl.download!(std.net.curl.HTTP).download at C:\D\dmd2\windows\bin\..\..\src\phobos\std\net\curl.d(431)
0x009611EC in std.net.curl.download!(std.net.curl.AutoProtocol).download at C:\D\dmd2\windows\bin\..\..\src\phobos\std\net\curl.d(440)
0x0094F3D7 in served.commands.dcd_update.updateDCD at C:\Temp\serve-d\source\served\commands\dcd_update.d(113)
0x0091C848 in std.functional.DelegateFaker!(void function()).DelegateFaker.doIt at C:\D\dmd2\windows\bin\..\..\src\phobos\std\functional.d-mixin-1430(1442)
0x00D8465D in void core.thread.Fiber.run()
````