### PR TITLE
Improve Ddoc formatting and show function intellisense while typing parameters Fixes Pure-D/code-d#51

### DIFF
--- a/source/served/commands/calltips.d
+++ b/source/served/commands/calltips.d
@@ -13,10 +13,10 @@ import std.algorithm : max;
 /**
  * Convert DCD calltips to LSP compatible `SignatureHelp` objects
  * Params:
- * 		calltips = Ddoc strings for each available calltip
- * 		symbols = array of possible signatures as DCD symbols
- *      textTilCursor = The entire contents of the file being edited up until
- * 		the cursor
+ *      calltips = Ddoc strings for each available calltip
+ *      symbols = array of possible signatures as DCD symbols
+ *      textTilCursor = The entire contents of the file being edited up
+ *                      until the cursor
  */
 SignatureHelp convertDCDCalltips(string[] calltips,
 		DCDCompletions.Symbol[] symbols, string textTilCursor)
@@ -39,13 +39,11 @@ SignatureHelp convertDCDCalltips(string[] calltips,
 		help.signatures ~= sig;
 	}
 	auto extractedParams = textTilCursor.extractFunctionParameters(true);
-	help.activeParameter = max(0, cast(int) extractedParams.length - 1);
 	size_t[] possibleFunctions;
 	foreach (i, count; paramsCounts)
 		if (count >= cast(int) extractedParams.length - 1)
 			possibleFunctions ~= i;
 
-	help.activeParameter = cast(int)extractedParams.length - 1;
 	help.activeSignature = possibleFunctions.length ? cast(int) possibleFunctions[0] : 0;
 	return help;
 }
@@ -69,7 +67,7 @@ SignatureHelp provideDSignatureHelp(TextDocumentPositionParams params,
 	if (!backend.has!DCDComponent(workspaceRoot))
 		return SignatureHelp.init;
 
-	auto currOffset = cast(int) document.positionToOffset(params.position);
+	auto currOffset = cast(int) document.positionToBytes(params.position);
 
 	// Show call tip if open bracket is on same line and and not followed by
 	// close bracket. Not as reliable as AST parsing but much faster and should

--- a/source/served/commands/calltips.d
+++ b/source/served/commands/calltips.d
@@ -10,11 +10,19 @@ import workspaced.coms;
 
 import std.algorithm : max;
 
+/**
+ * Convert DCD calltips to LSP compatible `SignatureHelp` objects
+ * Params:
+ * 		calltips = Ddoc strings for each available calltip
+ * 		symbols = array of possible signatures as DCD symbols
+ *      textTilCursor = The entire contents of the file being edited up until
+ * 		the cursor
+ */
 SignatureHelp convertDCDCalltips(string[] calltips,
 		DCDCompletions.Symbol[] symbols, string textTilCursor)
 {
 	SignatureInformation[] signatures;
-	int[] paramsCounts;
+	int[] paramsCounts; // Number of params for each calltip
 	SignatureHelp help;
 	foreach (i, calltip; calltips)
 	{
@@ -36,6 +44,8 @@ SignatureHelp convertDCDCalltips(string[] calltips,
 	foreach (i, count; paramsCounts)
 		if (count >= cast(int) extractedParams.length - 1)
 			possibleFunctions ~= i;
+
+	help.activeParameter = cast(int)extractedParams.length - 1;
 	help.activeSignature = possibleFunctions.length ? cast(int) possibleFunctions[0] : 0;
 	return help;
 }
@@ -59,14 +69,28 @@ SignatureHelp provideDSignatureHelp(TextDocumentPositionParams params,
 	if (!backend.has!DCDComponent(workspaceRoot))
 		return SignatureHelp.init;
 
-	auto pos = cast(int) document.positionToBytes(params.position);
+	auto currOffset = cast(int) document.positionToOffset(params.position);
+
+	// Show call tip if open bracket is on same line and and not followed by
+	// close bracket. Not as reliable as AST parsing but much faster and should
+	// work for 90%+ of cases.
+	import std.algorithm : countUntil;
+	import std.range: retro;
+	auto openBracketOffset = document.text[0..currOffset].retro().countUntil("(");
+	auto closeBracketOffset = document.text[0..currOffset].retro().countUntil(")");
+	auto nlBracketOffset = document.text[0..currOffset].retro().countUntil("\n");
+	if (openBracketOffset >= 0 && openBracketOffset < closeBracketOffset
+			&& openBracketOffset < nlBracketOffset) {
+		currOffset -= openBracketOffset;
+	}
+
 	DCDCompletions result = backend.get!DCDComponent(workspaceRoot)
-		.listCompletion(document.text, pos).getYield;
+		.listCompletion(document.text, currOffset).getYield;
 	switch (result.type)
 	{
 	case DCDCompletions.Type.calltips:
 		return convertDCDCalltips(result.calltips,
-				result.symbols, document.text[0 .. pos]);
+				result.symbols, document.text[0 .. currOffset]);
 	case DCDCompletions.Type.identifiers:
 		return SignatureHelp.init;
 	default:

--- a/source/served/commands/complete.d
+++ b/source/served/commands/complete.d
@@ -138,6 +138,13 @@ string substr(T)(string s, T start, T end)
 	return s[start .. end];
 }
 
+/**
+ * Take a function signature and return an array of parameters. May wish to do
+ * this in dparse or a library created for this purpose but seems to work fine.
+ * Params:
+ * 		sig = a string of a function signature e.g. `int f(string arg);`
+ *		exact = perform a more more accurate but slower parsing (I think).
+ */
 string[] extractFunctionParameters(string sig, bool exact = false)
 {
 	if (!sig.length)

--- a/source/served/commands/complete.d
+++ b/source/served/commands/complete.d
@@ -138,13 +138,10 @@ string substr(T)(string s, T start, T end)
 	return s[start .. end];
 }
 
-/**
- * Take a function signature and return an array of parameters. May wish to do
- * this in dparse or a library created for this purpose but seems to work fine.
- * Params:
- * 		sig = a string of a function signature e.g. `int f(string arg);`
- *		exact = perform a more more accurate but slower parsing (I think).
- */
+/// Extracts all function parameters for a given declaration string.
+/// Params:
+///   sig = the function signature such as `string[] example(string sig, bool exact = false)`
+///   exact = set to true to make the returned values include the closing paren at the end (if exists)
 string[] extractFunctionParameters(string sig, bool exact = false)
 {
 	if (!sig.length)

--- a/source/served/ddoc.d
+++ b/source/served/ddoc.d
@@ -31,7 +31,6 @@ private int testFunction(string foo, int bar)
 	return 0;
 }
 
-
 /**
  * Convert a Ddoc comment string to markdown. Returns ddoc string back if it is
  * not valid.
@@ -77,8 +76,8 @@ string ddocToMarkdown(string ddoc)
 		default:
 			// Single line sections go on the same line as section titles. Multi
 			// line sections go on the line below.
-			import std.algorithm : find;
-			if (section.content.chomp().find('\n').empty)
+			import std.algorithm : canFind;
+			if (!section.content.chomp.canFind("\n"))
 			{
 				output ~= format!"**%s** — %s\n\n"(section.name, section.content.chomp());
 			}
@@ -153,7 +152,7 @@ private string prepareDDoc(string str)
 	return output;
 }
 
-private string[string] markdownMacros;
+string[string] markdownMacros;
 shared static this()
 {
 	//dfmt off

--- a/source/served/extension.d
+++ b/source/served/extension.d
@@ -315,7 +315,7 @@ InitializeResult initialize(InitializeParams params)
 
 	InitializeResult result;
 	result.capabilities.textDocumentSync = documents.syncKind;
-	result.capabilities.completionProvider = CompletionOptions(false, [".", "(", "[", "="]);
+	result.capabilities.completionProvider = CompletionOptions(false, [".", "="]);
 	result.capabilities.signatureHelpProvider = SignatureHelpOptions(["(", "[", ","]);
 	result.capabilities.workspaceSymbolProvider = true;
 	result.capabilities.definitionProvider = true;


### PR DESCRIPTION
So this pull request should really improve the utility and usability of the documentation viewer. The viewer has been fully stylised (including params formatted separate lines etc.) and will now stay open while you are typing the arguments for the function. The algorithm for detecting whether the cursor is in the middle of a function call is a bit basic but does the job fine. Let me know what you think :thinking: 

![calltips](https://user-images.githubusercontent.com/4366510/51280689-3b4c5780-19d8-11e9-8cb7-3eeb0febe08a.gif)
