### PR TITLE
Let dub decide for wich --arch to build

### DIFF
--- a/source/served/commands/dcd_update.d
+++ b/source/served/commands/dcd_update.d
@@ -95,16 +95,13 @@ void updateDCD()
 
 	if (compileFromSource)
 	{
-		string[] platformOptions;
-		version (Windows)
-			platformOptions = ["--arch=x86_mscoff"];
 		success = compileDependency(outputFolder, "DCD",
 				"https://github.com/dlang-community/DCD.git", [
 					[
 						firstConfig.git.userPath, "submodule", "update", "--init",
 						"--recursive"
-					], ["dub", "build", "--config=client"] ~ platformOptions,
-					["dub", "build", "--config=server"] ~ platformOptions
+					], ["dub", "build", "--config=client"],
+					["dub", "build", "--config=server"]
 				]);
 		finalDestinationClient = buildPath(outputFolder, "DCD", "dcd-client" ~ ext);
 		if (!fs.exists(finalDestinationClient))


### PR DESCRIPTION
By default it compiles with x86, x86_mscoff

But if user doesn't have a x86 compiler, it'll produce bad executable with undefined symbols, as a result it won't work, specially with LDC (haven't tested with DMD)

So let dub decide wich to use based on wich is available