### PR TITLE
Add dub install instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -650,6 +650,10 @@ Manually building from source:
 dub build
 ```
 
+serve-d is also on DUB:
+```
+dub fetch serve-d
+```
 ## Issues
 
 If you have issues with any editors using serve-d, please [report an issue](https://github.com/Pure-D/serve-d/issues/new)


### PR DESCRIPTION
This adds installation instructions for using DUB, since serve-d is on dub, it's usually a bit easier to use dub, instead of putting binaries in your $PATH.