### PR TITLE
add emacs guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ _add LSP configurations using serve-d for other editors and PR them here!_
 
 * [vim](editor-vim.md)
 * [sublime text](editor-st.md)
+* [emacs](editor-emacs.md)
 
 ### Command Line options
 

--- a/editor-emacs.md
+++ b/editor-emacs.md
@@ -1,0 +1,26 @@
+# serve-d with Emacs
+
+## Using eglot
+
+Download or build
+
+* [serve-d](README.md#Installation)
+* [eglot](https://github.com/joaotavora/eglot#1-2-3)
+* [d-mode](https://github.com/Emacs-D-Mode-Maintainers/Emacs-D-Mode)
+
+And edit your `$HOME/.emacs` or `$HOME/.emacs.d/init.el`.
+
+```elisp
+(add-hook 'd-mode-hook 'eglot-ensure)
+(add-to-list 'eglot-server-programs `(d-mode . ("/path/to/your/serve-d")))
+```
+
+OPTIONAL: If you want to customize serve-d (e.g. specifying paths), add
+
+```elisp
+(setq-default eglot-workspace-configuration
+  '((:d . (:stdlibPath ("/path/to/dmd-2.098.0/src/phobos"
+                        "/path/to/dmd-2.098.0/src/druntime/src")))))
+```
+
+For per-project config, add [.dir-locals.el](https://github.com/joaotavora/eglot#per-project-server-configuration) in your project root.


### PR DESCRIPTION
I recently replaced [company-dcd](https://github.com/tsukimizake/company-dcd) with serve-d + eglot in my emacs because it works pretty well.

![image](https://user-images.githubusercontent.com/6745326/142748012-d87fb176-3f99-42aa-9225-232d8b62105b.png)

I hope this PR can help some emacs users try serve-d (e.g. #109).