### PR TITLE
Prevent serve-d to consume 100% cpu whenever vscode is closed

### DIFF
--- a/lsp/source/served/lsp/filereader.d
+++ b/lsp/source/served/lsp/filereader.d
@@ -136,7 +136,7 @@ version (Posix) class PosixStdinReader : FileReader
 		running = true;
 
 		ubyte[4096] buffer;
-		while (running && !stdin.error() && !stdin.eof))
+		while (running && !stdin.error() && !stdin.eof)
 		{
 			fd_set rfds;
 			timeval tv;

--- a/lsp/source/served/lsp/filereader.d
+++ b/lsp/source/served/lsp/filereader.d
@@ -136,7 +136,7 @@ version (Posix) class PosixStdinReader : FileReader
 		running = true;
 
 		ubyte[4096] buffer;
-		while (running)
+		while (running && !stdin.error() && !stdin.eof))
 		{
 			fd_set rfds;
 			timeval tv;


### PR DESCRIPTION
This at least doesn't make serve-d to consume 100% of the cpu..

It still doesn't close.. but at least it doesn't cause too much problems..

But since this doesn't consume 100% cpu after this change, this might be an indication on why process doesn't close, what ever thread is calling that method is stuck! that needs to be investigated!