### PR TITLE
Limit line length warning range to line length

### DIFF
--- a/source/served/linters/dscanner.d
+++ b/source/served/linters/dscanner.d
@@ -124,7 +124,8 @@ bool adjustRangeForType(ref Diagnostic d, Document document, DScannerIssue issue
 	if (s.startsWith("Line is longer than ") && s.endsWith(" characters"))
 	{
 		d.range.start.character = s["Line is longer than ".length .. $ - " characters".length].to!uint;
-		d.range.end.character = 1000;
+		d.range.end.line = d.range.start.line + 1;
+		d.range.end.character = 0;
 	}
 
 	return true;


### PR DESCRIPTION
(I haven't tested this, because I can't get a build on macOS M1.)