### PR TITLE
Nova extension updates.

### DIFF
--- a/editor-nova.md
+++ b/editor-nova.md
@@ -3,8 +3,8 @@
 
 ## Summary
 
-An extension for Nova is [available][2] via the normal
-extension facility.
+An extension for Nova called **D-Velop** is [available][2] via the normal
+extension facility.  This extension utilizes serve-d for LSP functionality.
 
 Installing this will enable D support to work in Nova.
 
@@ -13,20 +13,13 @@ indentation features via the Tree-sitter [D grammar][4].
 
 ## Requirements
 
-You will need a version of serve-d newer than **0.7.4**.
-As of this moment, no such release exists, but if you
-use a current nightly or build serve-d yourself, then it
-should work fine.
+**D-Velop** will offer to automatically download a suitable
+version of serve-d, and by default will notify you when new
+releases are available, and offer to update as appropriate.
 
-## Configuration
-
-If the `serve-d` binary is not in `/usr/local/bin`,
-then you will need to set the path.  This can be done
-in the **Extensions → Extension Library...** panel
-by clicking the **Settings** tab for the *Serve-D* extension. 
-
-Set the `Language Server Path` to the location where your
-`serve-d` binary can be found.
+You can use your own installation of serve-d as well, but
+be advised that served version **0.8.0-beta.1 or newer** is
+required to operate with the extension
 
 [1]: https://nova.app "Nova Editor" 
 [2]: https://extensions.panic.com/extensions/tech.staysail/tech.staysail.ServeD/ "Serve-D plugin for nova"


### PR DESCRIPTION
The extension was renamed, and now offers frictionless updates of serve-d (from GitHub releases.)