### PR TITLE
Add a non-standard served/didConfigurationChange

### DIFF
--- a/README.md
+++ b/README.md
@@ -594,6 +594,15 @@ interface ProfileGCEntry
 }
 ```
 
+#### Notification `served/didConfigurationChange`
+
+**Params**: Exactly as for `workspace/didConfigurationChange`
+
+This notification triggers the use of alternate configuration notifications.
+Once this is received, the server will ignore `workspace/didConfigurationChange`
+notifications.  This mechanisms exists to support some client/plugin combinations
+where the plugin needs more direct control over the configuration.
+
 ------
 
 #### Client notification `coded/updateSetting`

--- a/protocol/source/served/lsp/protocol.d
+++ b/protocol/source/served/lsp/protocol.d
@@ -2237,13 +2237,12 @@ struct DidChangeConfigurationClientCapabilities
 /// You might want to use `RootJsonToken` instead of this type if you want to
 /// deserialize your custom config types.
 @serdeFallbackStruct
-@allowedMethods("workspace/didChangeConfiguration", "served/didChangeConfiguration")
+@allowedMethods("workspace/didChangeConfiguration")
 struct DidChangeConfigurationParams
 {
 	JsonValue settings;
 }
 
-@serdeFallbackStruct
 @serdeFallbackStruct
 @allowedMethods("workspace/configuration")
 struct ConfigurationParams

--- a/protocol/source/served/lsp/protocol.d
+++ b/protocol/source/served/lsp/protocol.d
@@ -2237,12 +2237,13 @@ struct DidChangeConfigurationClientCapabilities
 /// You might want to use `RootJsonToken` instead of this type if you want to
 /// deserialize your custom config types.
 @serdeFallbackStruct
-@allowedMethods("workspace/didChangeConfiguration")
+@allowedMethods("workspace/didChangeConfiguration", "served/didChangeConfiguration")
 struct DidChangeConfigurationParams
 {
 	JsonValue settings;
 }
 
+@serdeFallbackStruct
 @serdeFallbackStruct
 @allowedMethods("workspace/configuration")
 struct ConfigurationParams

--- a/serverbase/source/served/utils/serverconfig.d
+++ b/serverbase/source/served/utils/serverconfig.d
@@ -129,7 +129,7 @@ mixin template ConfigHandler(TConfig)
 
 	private __gshared bool _hasConfigurationCapability = false;
 
-	__gshared bool nonStandardConfiguration = false;
+	private __gshared bool nonStandardConfiguration = false;
 
 	@postProtocolMethod("initialize")
 	void postInit_setupConfig(InitializeParams params)

--- a/serverbase/source/served/utils/serverconfig.d
+++ b/serverbase/source/served/utils/serverconfig.d
@@ -47,7 +47,7 @@ struct ConfigWorkspace
 
 	string toString() const @safe {
 		import std.conv : text;
-	
+
 		return isUnnamedWorkspace
 			? "(unnamed workspace)"
 			: uri;
@@ -129,6 +129,8 @@ mixin template ConfigHandler(TConfig)
 
 	private __gshared bool _hasConfigurationCapability = false;
 
+	__gshared bool nonStandardConfiguration = false;
+
 	@postProtocolMethod("initialize")
 	void postInit_setupConfig(InitializeParams params)
 	{
@@ -188,10 +190,25 @@ mixin template ConfigHandler(TConfig)
 	void didChangeConfiguration(RootJsonToken params)
 	{
 		import std.exception;
-
+		if (nonStandardConfiguration) { // client prefers non-standard API
+			return;
+		}
 		enforce(params.json.looksLikeJsonObject, "invalid non-object parameter to didChangeConfiguration");
 		auto settings = params.json.parseKeySlices!"settings".settings;
 		enforce(settings.length, `didChangeConfiguration must contain a "settings" key`);
+
+		processConfigChange(settings.deserializeJson!TConfig);
+	}
+
+	@protocolNotification("served/didChangeConfiguration")
+	void didChangeConfigurationNonStd(RootJsonToken params)
+	{
+		import std.exception;
+		info("switching to nonstandard configuration mechanism");
+		nonStandardConfiguration = true; // client prefers non-standard API
+		enforce(params.json.looksLikeJsonObject, "invalid non-object parameter to served/didChangeConfiguration");
+		auto settings = params.json.parseKeySlices!"settings".settings;
+		enforce(settings.length, `served/didChangeConfiguration must contain a "settings key"`);
 
 		processConfigChange(settings.deserializeJson!TConfig);
 	}


### PR DESCRIPTION
This overrides the standard workspace/ variant, and once used, will be the only way that configuration notifications can be made.  This is a workaround for clients that cannot use the normal mechanism.