### PR TITLE
RegularExpressionsClientCapabilities version field is optional

### DIFF
--- a/protocol/source/served/lsp/protocol.d
+++ b/protocol/source/served/lsp/protocol.d
@@ -1879,7 +1879,7 @@ struct GeneralClientCapabilities
 struct RegularExpressionsClientCapabilities
 {
 	string engine;
-	@serdeKeys("version") Optional!string version_;
+	@serdeKeys("version") @serdeOptional Optional!string version_;
 }
 
 unittest


### PR DESCRIPTION
https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#regExp

Otherwise it crashes with SublimeText

SublimeText support is btw broken again, it keep ask to redownload DCD