### PR TITLE
fix mir.ion error

### DIFF
--- a/protocol/source/served/lsp/protocol.d
+++ b/protocol/source/served/lsp/protocol.d
@@ -1681,7 +1681,7 @@ unittest
 struct InitializeParamsClientInfo
 {
 	string name;
-	@serdeKeys("version") Optional!string version_;
+	@serdeKeys("version") @serdeOptional Optional!string version_;
 }
 
 @serdeFallbackStruct


### PR DESCRIPTION
 -32603: mir.ion: non-optional member 'version_' in InitializeParamsClientInfo is missing.