### PR TITLE
fixing missing params and proper end brackets to message registerCapability

### DIFF
--- a/lsp/source/served/lsp/jsonrpc.d
+++ b/lsp/source/served/lsp/jsonrpc.d
@@ -225,13 +225,13 @@ class RPCProcessor : Fiber
 	void registerCapability(T)(scope const(char)[] id, scope const(char)[] method, T options)
 	{
 		const(char)[][7] parts = [
-			`{"jsonrpc":"2.0","method":"client/registerCapability","registrations":[{"id":"`,
+			`{"jsonrpc":"2.0","method":"client/registerCapability","params":{"registrations":[{"id":"`,
 			id.escapeJsonStringContent,
 			`","method":"`,
 			method.escapeJsonStringContent,
 			`","registerOptions":`,
 			options.serializeJson,
-			`]}`
+			`}]}}`
 		];
 		sendRawPacket(parts[]);
 	}


### PR DESCRIPTION
I have painstakingly debugged serve-d for quite some time,
since coc didn't work after some major changes, and I have finally discovered why (see in the PR),
It is quite error prone to manually build these messages, so I am guessing we need some tests to ensure the 
expected message.

I think why other lsp clients works is because they just ignore invalid messages, whereas coc is way more strict and just shutdowns the server when it receives something invalid. 
