### PR TITLE
Specify SaveOptions in server capabilities

### DIFF
--- a/source/served/extension.d
+++ b/source/served/extension.d
@@ -260,6 +260,13 @@ InitializeResult initialize(InitializeParams params)
 	}
 
 	InitializeResult result;
+	SaveOptions save = {
+		includeText: false,
+	};
+	TextDocumentSyncOptions textDocumentSync = {
+		change: documents.syncKind,
+		save: save,
+	};
 	CompletionOptions completionProvider = {
 		resolveProvider: doCompleteSnippets,
 		triggerCharacters: [
@@ -285,7 +292,7 @@ InitializeResult initialize(InitializeParams params)
 	};
 	FoldingRangeOptions foldingRangeProvider;
 	ServerCapabilities serverCapabilities = {
-		textDocumentSync: documents.syncKind,
+		textDocumentSync: textDocumentSync,
 		// only provide fixes when doCompleteSnippets is requested
 		completionProvider: completionProvider,
 		referencesProvider: true,


### PR DESCRIPTION
`textDocument/didSave` is specified by the server capability of SaveOptions or bool in the TextDocumentSyncOptions. Since this wasn't getting set, some clients may not send `textDocument/didSave` since the server never broadcasted this capability.

`includeText` is set to `false` since I didn't see anywhere we use the text contents when responding to this method.

I've confirmed this fixes a bug in the client `helix` as dub build lints weren't getting triggered since it wouldn't send the `textDocument/didSave` message unless this capability was sent.

Relevant docs: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_didSave

Related issue on Helix side: https://github.com/helix-editor/helix/pull/3957