### PR TITLE
add openClose document sync capabitilty

### DIFF
--- a/source/served/extension.d
+++ b/source/served/extension.d
@@ -264,6 +264,7 @@ InitializeResult initialize(InitializeParams params)
 		includeText: false,
 	};
 	TextDocumentSyncOptions textDocumentSync = {
+		openClose: true,
 		change: documents.syncKind,
 		save: save,
 	};


### PR DESCRIPTION
`textDocument/didOpen` was not sent anymore by VS code since #320