### PR TITLE
Fix undefined identifier 'trace' error.

### DIFF
--- a/source/served/commands/format.d
+++ b/source/served/commands/format.d
@@ -8,6 +8,7 @@ import workspaced.com.snippets : SnippetLevel;
 import workspaced.coms;
 
 import std.conv : to;
+import std.experimental.logger : trace;
 import std.json;
 import std.string;
 


### PR DESCRIPTION
When compiling master (my personal setup was ldc2 and running release.sh), I ran into an error saying that 'trace' is an undefined identifier in `source/served/commands/format.d`. I assume the desired function is `std.experimental.logger.trace()`, so I've added the import.