### PR TITLE
Fix build on musl libc systems

### DIFF
--- a/source/crash_handler.d
+++ b/source/crash_handler.d
@@ -1,6 +1,8 @@
 module crash_handler;
 
-version (linux)
+version (CRuntime_Musl)
+	enum BacktraceHandler = false;
+else version (linux)
 	enum BacktraceHandler = true;
 else version (OSX)
 	enum BacktraceHandler = true;


### PR DESCRIPTION
MUSL libc (used on Alpine Linux and others) doesn't provide the `backtrace_*` symbols used by the optional `BacktraceHandler` functionality, so disable it when `CRuntime_Musl`.