### PR TITLE
dcd: Include missing dependency on unit-threaed

### DIFF
--- a/dcd/dub.sdl
+++ b/dcd/dub.sdl
@@ -1,3 +1,4 @@
 name "dcd"
 
 dependency "dcd:common" version="~>0.16.0-beta.1"
+dependency "unit-threaded:assertions" version=">=0.0.0"

--- a/dcd/source/served/dcd/client.d
+++ b/dcd/source/served/dcd/client.d
@@ -690,6 +690,7 @@ private string unescapeTabs(string val)
 
 unittest
 {
+	import unit_threaded.assertions;
 	shouldEqual("hello world", "hello world".unescapeTabs);
 	shouldEqual("hello\nworld", "hello\\nworld".unescapeTabs);
 	shouldEqual("hello\\nworld", "hello\\\\nworld".unescapeTabs);


### PR DESCRIPTION
The dcd subpackage is failing tests due to a missing dependency and import.