### PR TITLE
Adds support for dscanner.excludedFiles

### DIFF
--- a/source/served/types.d
+++ b/source/served/types.d
@@ -138,6 +138,9 @@ struct Configuration
 	{
 		@serdeOptional:
 		string[] ignoredKeys;
+
+		@serdeOptional
+		string[] excludedFiles;
 	}
 
 	struct SDL

--- a/source/served/types.d
+++ b/source/served/types.d
@@ -139,7 +139,6 @@ struct Configuration
 		@serdeOptional:
 		string[] ignoredKeys;
 
-		@serdeOptional
 		string[] excludedFiles;
 	}
 


### PR DESCRIPTION
This adds the option dscanner.excludedFiles, wich can be used to exclude certain files from being linted with dscanner. Usefull for using with generated d code, for example when using dstep with c code.

Each exclude option is an glob that is matched against the workspace relative document uri.