### PR TITLE
Support ldc2.conf as a directory

### DIFF
--- a/source/served/utils/stdlib_detect.d
+++ b/source/served/utils/stdlib_detect.d
@@ -259,8 +259,8 @@ private string getUserHomeDirectoryLDC()
 {
 	version (Windows)
 	{
-		import core.sys.windows.windows;
 		import core.sys.windows.shlobj;
+		import core.sys.windows.windows;
 
 		wchar[MAX_PATH] buf;
 		HRESULT res = SHGetFolderPathW(null, CSIDL_FLAG_CREATE | CSIDL_APPDATA, null, SHGFP_TYPE
@@ -424,7 +424,7 @@ void parseLdcConfImportsSingleFile(string confPath, scope const(char)[] binDirPa
 	catch (Exception e)
 		throw new Exception("Could not read ldc2 config file: " ~ confPath ~ ": " ~ e.msg);
 
-	foreach (s; parseConfigFile(confPath))
+	foreach (s; settings)
 	{
 		if (s.type == Setting.Type.group && s.name == "default")
 		{


### PR DESCRIPTION
This PR is based on https://github.com/Pure-D/serve-d/pull/396 and adds support for the upcoming ldc2 change of allowing `ldc2.conf` to be a directory.

The ldc2 PR can be found at https://github.com/ldc-developers/ldc/pull/4954.

---

For safety, it would be best to wait for the ldc2 PR to be merged before merging this.