### PR TITLE
jsonrpc: allow a timeout on requestMessage, use it for the DCD prompt

### DIFF
--- a/lsp/source/served/lsp/jsonrpc.d
+++ b/lsp/source/served/lsp/jsonrpc.d
@@ -953,22 +953,28 @@ struct WindowFunctions
 	}
 
 	/// Runs window/showMessageRequest which typically shows a message box with possible action buttons to click. Returns the action which got clicked or one with null title if it has been dismissed.
-	MessageActionItem requestMessage(MessageType type, string message, MessageActionItem[] actions)
+	///
+	/// Params:
+	///   timeout = how long to wait for an answer; throws once it elapses. Clients
+	///     are not required to ever answer.
+	MessageActionItem requestMessage(MessageType type, string message,
+		MessageActionItem[] actions, Duration timeout = Duration.max)
 	{
 		auto res = rpc.sendRequest("window/showMessageRequest",
-				ShowMessageRequestParams(type, message, actions.opt));
+				ShowMessageRequestParams(type, message, actions.opt), timeout);
 		if (!res.resultJson.length || res.resultJson == `null`)
 			return MessageActionItem(null);
 		return res.resultJson.deserializeJson!MessageActionItem;
 	}
 
 	/// ditto
-	string requestMessage(MessageType type, string message, string[] actions)
+	string requestMessage(MessageType type, string message, string[] actions,
+		Duration timeout = Duration.max)
 	{
 		MessageActionItem[] a = new MessageActionItem[actions.length];
 		foreach (i, action; actions)
 			a[i] = MessageActionItem(action);
-		return requestMessage(type, message, a).title;
+		return requestMessage(type, message, a, timeout).title;
 	}
 
 	/// Runs a function and shows a UI message on failure and logs the error.

--- a/lsp/source/served/lsp/jsonrpc.d
+++ b/lsp/source/served/lsp/jsonrpc.d
@@ -414,6 +414,10 @@ class RPCProcessor : Fiber
 
 		StopWatch sw;
 		sw.start();
+		// a timed-out wait must release its slot too, or prepareWait can never
+		// reuse it
+		scope (failure)
+			responseTokens[i].handled = true;
 		while (!responseTokens[i].got)
 		{
 			if (timeout != Duration.max

--- a/source/served/extension.d
+++ b/source/served/extension.d
@@ -856,11 +856,23 @@ void delayedProjectActivation(WorkspaceD.Instance instance, string workspaceRoot
 								missingList = missingList[0 .. comma + 1] ~ " ...";
 						}
 
-						auto res = rpc.window.requestMessage(
-							MessageType.info,
-							translate!"d.dub.downloadMissingMsg"(missingList),
-							[upgrade, always, never]
-						);
+						// some clients never answer; empty res downloads nothing, as
+						// dismissing would
+						enum promptTimeout = 10.minutes;
+
+						string res;
+						try
+							res = rpc.window.requestMessage(
+								MessageType.info,
+								translate!"d.dub.downloadMissingMsg"(missingList),
+								[upgrade, always, never],
+								promptTimeout
+							);
+						catch (Exception e)
+							warningf("No answer to the missing dependency prompt "
+								~ "after %s, not downloading: %s", promptTimeout,
+								e.msg);
+
 						if (res == always)
 						{
 							rpc.notifyMethod("coded/updateSetting", UpdateSettingParams("forceDownloadDependencies",

--- a/source/served/extension.d
+++ b/source/served/extension.d
@@ -779,9 +779,19 @@ void delayedProjectActivation(WorkspaceD.Instance instance, string workspaceRoot
 				}
 				auto loadButton = translate!"d.served.tooManySubprojects.load";
 				auto skipButton = translate!"d.served.tooManySubprojects.skip";
-				auto res = rpc.window.requestMessage(MessageType.warning,
-						translate!"d.served.tooManySubprojects.path"(root.dir),
-						[loadButton, skipButton]);
+
+				// some clients never answer; empty res skips, as dismissing would
+				enum promptTimeout = 10.minutes;
+
+				string res;
+				try
+					res = rpc.window.requestMessage(MessageType.warning,
+							translate!"d.served.tooManySubprojects.path"(root.dir),
+							[loadButton, skipButton], promptTimeout);
+				catch (Exception e)
+					warningf("No answer to the subproject load prompt for %s after "
+						~ "%s, skipping it: %s", root.dir, promptTimeout, e.msg);
+
 				if (res != loadButton)
 					goto case ManyProjectsAction.skip;
 				break;

--- a/source/served/extension.d
+++ b/source/served/extension.d
@@ -9,7 +9,7 @@ import served.utils.translate;
 
 public import served.utils.async;
 
-import core.time : msecs, seconds;
+import core.time : minutes, msecs, seconds;
 
 import std.algorithm : any, canFind, endsWith, map, remove;
 import std.array : appender, array;
@@ -451,7 +451,20 @@ void doGlobalStartup(UserConfiguration config)
 					if (!backend.has!DCDComponent)
 						actions.length--;
 
-					auto res = rpc.window.requestMessage(MessageType.error, outdatedMessage, actions);
+					// some clients never answer; without a timeout this fiber would
+					// live for the rest of the process
+					enum promptTimeout = 10.minutes;
+
+					string res;
+					try
+						res = rpc.window.requestMessage(MessageType.error,
+							outdatedMessage, actions, promptTimeout);
+					catch (Exception e)
+					{
+						warningf("No answer to the DCD update prompt after %s, "
+							~ "giving up: %s", promptTimeout, e.msg);
+						return;
+					}
 
 					if (res == action)
 						spawnFiber("updateDCD", (&updateDCD).toDelegate);


### PR DESCRIPTION
Clients need not answer showMessageRequest. A fiber waiting on one that
never comes lives for the rest of the process and keeps the main loop from
going idle. Give the DCD update prompt 10 minutes.

(cherry picked from commit f18d73f3c4cc56c928d583db20be407c7db7be1e)