### PR TITLE
filereader: don't allocate on every yieldLine call

### DIFF
--- a/lsp/source/served/lsp/filereader.d
+++ b/lsp/source/served/lsp/filereader.d
@@ -265,6 +265,10 @@ abstract class FileReader : Thread
 
 	string yieldLine(bool* whileThisIs = null, bool equalToThis = true)
 	{
+		// hoisted: as a literal this allocates on every call, and this runs once
+		// per main loop iteration even when idle
+		static immutable ubyte[2] crlf = [cast(ubyte) '\r', cast(ubyte) '\n'];
+
 		ptrdiff_t index;
 		string ret;
 		while (whileThisIs is null || *whileThisIs == equalToThis)
@@ -272,7 +276,7 @@ abstract class FileReader : Thread
 			bool hasData;
 			synchronized (mutex)
 			{
-				index = data.countUntil([cast(ubyte) '\r', cast(ubyte) '\n']);
+				index = data.countUntil(crlf[]);
 				if (index != -1)
 				{
 					ret = cast(string) data[0 .. index].dup;


### PR DESCRIPTION
The CRLF array literal allocated per call, which is once per main loop iteration even when idle.

(cherry picked from commit c3e10922a9e7eae8777aef951e5134d78a2ef2f6)